### PR TITLE
しゃがみ機能の追加

### DIFF
--- a/FPS-Space/Assets/ImportedAssets/Standard Assets/Characters/FirstPersonCharacter/Prefabs/FPSController.prefab
+++ b/FPS-Space/Assets/ImportedAssets/Standard Assets/Characters/FirstPersonCharacter/Prefabs/FPSController.prefab
@@ -5,13 +5,13 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 400000}
-  - 143: {fileID: 14300000}
-  - 114: {fileID: 11400000}
-  - 54: {fileID: 5400000}
-  - 82: {fileID: 8200000}
+  - component: {fileID: 400000}
+  - component: {fileID: 14300000}
+  - component: {fileID: 11400000}
+  - component: {fileID: 5400000}
+  - component: {fileID: 8200000}
   m_Layer: 0
   m_Name: FPSController
   m_TagString: Untagged
@@ -24,12 +24,12 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 400002}
-  - 20: {fileID: 2000000}
-  - 81: {fileID: 8100000}
-  - 124: {fileID: 12474086}
+  - component: {fileID: 400002}
+  - component: {fileID: 2000000}
+  - component: {fileID: 8100000}
+  - component: {fileID: 12474086}
   m_Layer: 0
   m_Name: FirstPersonCharacter
   m_TagString: MainCamera
@@ -50,6 +50,7 @@ Transform:
   - {fileID: 400002}
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &400002
 Transform:
   m_ObjectHideFlags: 1
@@ -62,6 +63,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 400000}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!20 &2000000
 Camera:
   m_ObjectHideFlags: 1
@@ -92,10 +94,12 @@ Camera:
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 0
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
-  m_StereoMirrorMode: 0
 --- !u!54 &5400000
 Rigidbody:
   m_ObjectHideFlags: 1
@@ -134,6 +138,7 @@ AudioSource:
   Loop: 0
   Mute: 0
   Spatialize: 0
+  SpatializePostEffects: 0
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
@@ -146,12 +151,14 @@ AudioSource:
   rolloffCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - time: 0
+    - serializedVersion: 2
+      time: 0
       value: 1
       inSlope: 0
       outSlope: 0
       tangentMode: 0
-    - time: 1
+    - serializedVersion: 2
+      time: 1
       value: 0
       inSlope: 0
       outSlope: 0
@@ -162,7 +169,8 @@ AudioSource:
   panLevelCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - time: 0
+    - serializedVersion: 2
+      time: 0
       value: 1
       inSlope: 0
       outSlope: 0
@@ -173,7 +181,8 @@ AudioSource:
   spreadCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - time: 0
+    - serializedVersion: 2
+      time: 0
       value: 0
       inSlope: 0
       outSlope: 0
@@ -184,7 +193,8 @@ AudioSource:
   reverbZoneMixCustomCurve:
     serializedVersion: 2
     m_Curve:
-    - time: 0
+    - serializedVersion: 2
+      time: 0
       value: 1
       inSlope: 0
       outSlope: 0
@@ -204,8 +214,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_IsWalking: 0
+  m_IsCrouching: 0
   m_WalkSpeed: 5
   m_RunSpeed: 10
+  m_CrouchSpeed: 2.5
+  m_CrouchHeadDistance: 0.6
   m_RunstepLenghten: 0.7
   m_JumpSpeed: 10
   m_StickToGroundForce: 10
@@ -229,12 +242,14 @@ MonoBehaviour:
     IncreaseCurve:
       serializedVersion: 2
       m_Curve:
-      - time: 0
+      - serializedVersion: 2
+        time: 0
         value: 0
         inSlope: 0
         outSlope: 0
         tangentMode: 0
-      - time: 1
+      - serializedVersion: 2
+        time: 1
         value: 1
         inSlope: 2
         outSlope: 2
@@ -249,27 +264,32 @@ MonoBehaviour:
     Bobcurve:
       serializedVersion: 2
       m_Curve:
-      - time: 0
+      - serializedVersion: 2
+        time: 0
         value: 0
         inSlope: 0
         outSlope: 0
         tangentMode: 0
-      - time: 0.5
+      - serializedVersion: 2
+        time: 0.5
         value: 1
         inSlope: 0
         outSlope: 0
         tangentMode: 0
-      - time: 1
+      - serializedVersion: 2
+        time: 1
         value: 0
         inSlope: 0
         outSlope: 0
         tangentMode: 0
-      - time: 1.5
+      - serializedVersion: 2
+        time: 1.5
         value: -1
         inSlope: 0
         outSlope: 0
         tangentMode: 0
-      - time: 2
+      - serializedVersion: 2
+        time: 2
         value: 0
         inSlope: 0
         outSlope: 0

--- a/FPS-Space/Assets/ImportedAssets/Standard Assets/Characters/FirstPersonCharacter/Scripts/Command.cs
+++ b/FPS-Space/Assets/ImportedAssets/Standard Assets/Characters/FirstPersonCharacter/Scripts/Command.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UnityStandardAssets.Characters.FirstPerson
+{
+    //The parent class
+    public abstract class Command
+    {
+
+        //Do a command
+        public abstract void Execute();
+
+        //Undo a command
+        public virtual void Undo() { }
+
+    }
+
+
+    //
+    // Child classes
+    //
+
+    public class MoveForward : Command
+    {
+        //Called when we press a key
+        public override void Execute()
+        {
+            FirstPersonController.vertical += 1f;
+        }
+    }
+
+
+    public class MoveReverse : Command
+    {
+        //Called when we press a key
+        public override void Execute()
+        {
+            FirstPersonController.vertical -= 1f;
+        }
+    }
+
+
+    public class MoveLeft : Command
+    {
+        //Called when we press a key
+        public override void Execute()
+        {
+            FirstPersonController.horizontal -= 1f;
+        }
+    }
+
+
+    public class MoveRight : Command
+    {
+        //Called when we press a key
+        public override void Execute()
+        {
+            FirstPersonController.horizontal += 1f;
+        }
+    }
+
+    //For keys with no binding
+    public class NoCommand : Command
+    {
+        //Called when we press a key
+        public override void Execute()
+        {
+            //Nothing will happen if we press this key
+        }
+    }
+    
+    
+    public class SetIsCrouching : Command
+    {
+        //Called when we press a key
+        public override void Execute()
+        {
+            FirstPersonController.m_IsCrouching = true;
+        }
+        
+        //Undo a command
+        public override void Undo()
+        {
+            FirstPersonController.m_IsCrouching = false;
+        }
+    }
+        
+    public class SetIsWalking : Command
+    {
+        //Called when we press a key
+        public override void Execute()
+        {
+            FirstPersonController.m_IsWalking = false;
+        }
+        
+        //Undo a command
+        public override void Undo()
+        {
+            FirstPersonController.m_IsWalking = true;
+        }
+    }
+    
+    public class SetJump : Command
+    {
+        //Called when we press a key
+        public override void Execute()
+        {
+            FirstPersonController.m_Jump = true;
+        }
+        
+        //Undo a command
+        public override void Undo()
+        {
+            FirstPersonController.m_Jump = false;
+        }
+    }
+}

--- a/FPS-Space/Assets/ImportedAssets/Standard Assets/Characters/FirstPersonCharacter/Scripts/FirstPersonController.cs
+++ b/FPS-Space/Assets/ImportedAssets/Standard Assets/Characters/FirstPersonCharacter/Scripts/FirstPersonController.cs
@@ -11,8 +11,11 @@ namespace UnityStandardAssets.Characters.FirstPerson
     public class FirstPersonController : MonoBehaviour
     {
         [SerializeField] private bool m_IsWalking;
+        [SerializeField] private bool m_IsCrouching;
         [SerializeField] private float m_WalkSpeed;
         [SerializeField] private float m_RunSpeed;
+        [SerializeField] private float m_CrouchSpeed;
+        [SerializeField] private float m_CrouchHeadDistance;
         [SerializeField] [Range(0f, 1f)] private float m_RunstepLenghten;
         [SerializeField] private float m_JumpSpeed;
         [SerializeField] private float m_StickToGroundForce;
@@ -184,7 +187,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
             {
                 return;
             }
-            if (m_CharacterController.velocity.magnitude > 0 && m_CharacterController.isGrounded)
+            if(m_IsCrouching)
+            {
+                newCameraPosition = m_Camera.transform.localPosition;
+                newCameraPosition.y = m_OriginalCameraPosition.y - m_CrouchHeadDistance;
+            }
+            else if (m_CharacterController.velocity.magnitude > 0 && m_CharacterController.isGrounded)
             {
                 m_Camera.transform.localPosition =
                     m_HeadBob.DoHeadBob(m_CharacterController.velocity.magnitude +
@@ -210,12 +218,23 @@ namespace UnityStandardAssets.Characters.FirstPerson
             bool waswalking = m_IsWalking;
 
 #if !MOBILE_INPUT
-            // On standalone builds, walk/run speed is modified by a key press.
-            // keep track of whether or not the character is walking or running
+            // On standalone builds, walk/run/crouch speed is modified by a key press.
+            // keep track of whether the character is walking, running, or crouching
             m_IsWalking = !Input.GetKey(KeyCode.LeftShift);
+            
+            m_IsCrouching = Input.GetKey(KeyCode.C);
+            
 #endif
-            // set the desired speed to be walking or running
-            speed = m_IsWalking ? m_WalkSpeed : m_RunSpeed;
+            // set the desired speed to be walking, running, or crouching
+            if (m_IsCrouching)
+            {
+                speed = m_CrouchSpeed;
+            }
+            else
+            {
+                speed = m_IsWalking ? m_WalkSpeed : m_RunSpeed;   
+            }
+
             m_Input = new Vector2(horizontal, vertical);
 
             // normalize input if it exceeds 1 in combined length:

--- a/FPS-Space/Assets/ImportedAssets/Standard Assets/Characters/FirstPersonCharacter/Scripts/FirstPersonController.cs
+++ b/FPS-Space/Assets/ImportedAssets/Standard Assets/Characters/FirstPersonCharacter/Scripts/FirstPersonController.cs
@@ -10,8 +10,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
     [RequireComponent(typeof (AudioSource))]
     public class FirstPersonController : MonoBehaviour
     {
-        [SerializeField] private bool m_IsWalking;
-        [SerializeField] private bool m_IsCrouching;
         [SerializeField] private float m_WalkSpeed;
         [SerializeField] private float m_RunSpeed;
         [SerializeField] private float m_CrouchSpeed;
@@ -32,7 +30,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
         [SerializeField] private AudioClip m_LandSound;           // the sound played when character touches back on ground.
 
         private Camera m_Camera;
-        private bool m_Jump;
         private float m_YRotation;
         private Vector2 m_Input;
         private Vector3 m_MoveDir = Vector3.zero;
@@ -44,6 +41,13 @@ namespace UnityStandardAssets.Characters.FirstPerson
         private float m_NextStep;
         private bool m_Jumping;
         private AudioSource m_AudioSource;
+        
+        private Command noCommand, buttonW, buttonS, buttonA, buttonD, buttonC, buttonShift, buttonSpace;
+        public static float horizontal;
+        public static float vertical;
+        public static bool m_IsWalking;
+        public static bool m_IsCrouching;
+        public static bool m_Jump;
 
         // Use this for initialization
         private void Start()
@@ -58,34 +62,67 @@ namespace UnityStandardAssets.Characters.FirstPerson
             m_Jumping = false;
             m_AudioSource = GetComponent<AudioSource>();
 			m_MouseLook.Init(transform , m_Camera.transform);
+            
+            // Commands
+            noCommand = new NoCommand();
+            buttonW = new MoveForward();
+            buttonS = new MoveReverse();
+            buttonA = new MoveLeft();
+            buttonD = new MoveRight();
+            buttonC = new SetIsCrouching();
+            buttonShift = new SetIsWalking();
+            buttonSpace = new SetJump();
         }
 
 
         // Update is called once per frame
         private void Update()
         {
+            float speed;
+            GetInput(out speed);
+            
             RotateView();
-            // the jump state needs to read here to make sure it is not missed
-            if (!m_Jump)
-            {
-                m_Jump = CrossPlatformInputManager.GetButtonDown("Jump");
-            }
+            CameraMove(speed);
+            ProgressStepCycle(speed);
+            UpdateCameraPosition(speed);
 
             if (!m_PreviouslyGrounded && m_CharacterController.isGrounded)
             {
-                StartCoroutine(m_JumpBob.DoBobCycle());
-                PlayLandingSound();
-                m_MoveDir.y = 0f;
-                m_Jumping = false;
+                Land();
             }
+            
             if (!m_CharacterController.isGrounded && !m_Jumping && m_PreviouslyGrounded)
             {
-                m_MoveDir.y = 0f;
+                NotJump();
             }
 
             m_PreviouslyGrounded = m_CharacterController.isGrounded;
+            
+            m_MouseLook.UpdateCursorLock();
         }
 
+        private void CameraMove(float speed)
+        {
+            // always move along the camera forward as it is the direction that it being aimed at
+            Vector3 desiredMove = transform.forward*m_Input.y + transform.right*m_Input.x;
+            // get a normal for the surface that is being touched to move along it
+            RaycastHit hitInfo;
+            Physics.SphereCast(transform.position, m_CharacterController.radius, Vector3.down, out hitInfo,
+                m_CharacterController.height/2f, Physics.AllLayers, QueryTriggerInteraction.Ignore);
+            desiredMove = Vector3.ProjectOnPlane(desiredMove, hitInfo.normal).normalized;
+            
+            m_MoveDir.x = desiredMove.x*speed;
+            m_MoveDir.z = desiredMove.z*speed;
+        }
+        
+        
+        private void Land()
+        {
+            StartCoroutine(m_JumpBob.DoBobCycle());
+            PlayLandingSound();
+            m_MoveDir.y = 0f;
+            m_Jumping = false;
+        }
 
         private void PlayLandingSound()
         {
@@ -97,50 +134,61 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
         private void FixedUpdate()
         {
-            float speed;
-            GetInput(out speed);
-            // always move along the camera forward as it is the direction that it being aimed at
-            Vector3 desiredMove = transform.forward*m_Input.y + transform.right*m_Input.x;
-
-            // get a normal for the surface that is being touched to move along it
-            RaycastHit hitInfo;
-            Physics.SphereCast(transform.position, m_CharacterController.radius, Vector3.down, out hitInfo,
-                               m_CharacterController.height/2f, Physics.AllLayers, QueryTriggerInteraction.Ignore);
-            desiredMove = Vector3.ProjectOnPlane(desiredMove, hitInfo.normal).normalized;
-
-            m_MoveDir.x = desiredMove.x*speed;
-            m_MoveDir.z = desiredMove.z*speed;
-
 
             if (m_CharacterController.isGrounded)
             {
-                m_MoveDir.y = -m_StickToGroundForce;
+                Ground();
 
                 if (m_Jump)
                 {
-                    m_MoveDir.y = m_JumpSpeed;
-                    PlayJumpSound();
-                    m_Jump = false;
-                    m_Jumping = true;
+                    Jump();
                 }
             }
             else
             {
-                m_MoveDir += Physics.gravity*m_GravityMultiplier*Time.fixedDeltaTime;
+                Fall();
             }
+
+            Move();
+
+        }
+        
+        
+        private void Move()
+        {
             m_CollisionFlags = m_CharacterController.Move(m_MoveDir*Time.fixedDeltaTime);
-
-            ProgressStepCycle(speed);
-            UpdateCameraPosition(speed);
-
-            m_MouseLook.UpdateCursorLock();
         }
 
-
+        
+        private void Fall()
+        {
+            m_MoveDir += Physics.gravity*m_GravityMultiplier*Time.fixedDeltaTime;
+        }
+        
+        
+        private void Jump()
+        {
+            m_MoveDir.y = m_JumpSpeed;
+            PlayJumpSound();
+            m_Jump = false;
+            m_Jumping = true;
+        }
+        
+        private void NotJump()
+        {
+            m_MoveDir.y = 0f;
+        }
+        
         private void PlayJumpSound()
         {
             m_AudioSource.clip = m_JumpSound;
             m_AudioSource.Play();
+        }
+        
+        
+        private void Ground()
+        {
+            m_MoveDir.y = -m_StickToGroundForce;
         }
 
 
@@ -212,17 +260,56 @@ namespace UnityStandardAssets.Characters.FirstPerson
         private void GetInput(out float speed)
         {
             // Read input
-            float horizontal = CrossPlatformInputManager.GetAxis("Horizontal");
-            float vertical = CrossPlatformInputManager.GetAxis("Vertical");
-
+            
+            horizontal = 0;
+            vertical = 0;
+            
+            if (Input.GetKey(KeyCode.W))
+            {
+                buttonW.Execute();
+            }
+            if (Input.GetKey(KeyCode.S))
+            {
+                buttonS.Execute();
+            }
+            if (Input.GetKey(KeyCode.A))
+            {
+                buttonA.Execute();
+            }
+            if (Input.GetKey(KeyCode.D))
+            {
+                buttonD.Execute();
+            }
+            
             bool waswalking = m_IsWalking;
+
+            if (!m_Jump && CrossPlatformInputManager.GetButtonDown("Jump"))
+            {
+                buttonSpace.Execute();
+            }
+
 
 #if !MOBILE_INPUT
             // On standalone builds, walk/run/crouch speed is modified by a key press.
             // keep track of whether the character is walking, running, or crouching
-            m_IsWalking = !Input.GetKey(KeyCode.LeftShift);
+            //m_IsWalking = !Input.GetKey(KeyCode.LeftShift);
+            if (Input.GetKey(KeyCode.C))
+            {
+                buttonC.Execute();
+            }
+            else
+            {
+                buttonC.Undo();
+            }
             
-            m_IsCrouching = Input.GetKey(KeyCode.C);
+            if (Input.GetKey(KeyCode.LeftShift))
+            {
+                buttonShift.Execute();
+            }
+            else
+            {
+                buttonShift.Undo();
+            }
             
 #endif
             // set the desired speed to be walking, running, or crouching
@@ -230,9 +317,13 @@ namespace UnityStandardAssets.Characters.FirstPerson
             {
                 speed = m_CrouchSpeed;
             }
+            else if (m_IsWalking)
+            {
+                speed = m_WalkSpeed;
+            }
             else
             {
-                speed = m_IsWalking ? m_WalkSpeed : m_RunSpeed;   
+                speed = m_RunSpeed;   
             }
 
             m_Input = new Vector2(horizontal, vertical);
@@ -245,7 +336,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
             // handle speed change to give an fov kick
             // only if the player is going to a run, is running and the fovkick is to be used
-            if (m_IsWalking != waswalking && m_UseFovKick && m_CharacterController.velocity.sqrMagnitude > 0)
+            if (!m_IsCrouching && m_IsWalking != waswalking && m_UseFovKick && m_CharacterController.velocity.sqrMagnitude > 0)
             {
                 StopAllCoroutines();
                 StartCoroutine(!m_IsWalking ? m_FovKick.FOVKickUp() : m_FovKick.FOVKickDown());

--- a/FPS-Space/Assets/Main.unity
+++ b/FPS-Space/Assets/Main.unity
@@ -113,16 +113,12 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!4 &208326829 stripped
-Transform:
-  m_PrefabParentObject: {fileID: 400002, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
-  m_PrefabInternal: {fileID: 1632770551}
 --- !u!1001 &1041986958
 Prefab:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 208326829}
+    m_TransformParent: {fileID: 1329894645}
     m_Modifications:
     - target: {fileID: 400000, guid: e8ef930c672fcce4a88723bcce7a2591, type: 3}
       propertyPath: m_LocalPosition.x
@@ -138,7 +134,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: e8ef930c672fcce4a88723bcce7a2591, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: e8ef930c672fcce4a88723bcce7a2591, type: 3}
       propertyPath: m_LocalRotation.y
@@ -159,48 +155,10 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: e8ef930c672fcce4a88723bcce7a2591, type: 3}
   m_IsPrefabParent: 0
---- !u!1001 &1632770551
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
-  m_IsPrefabParent: 0
+--- !u!4 &1329894645 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400002, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
+  m_PrefabInternal: {fileID: 1947875331}
 --- !u!1 &1765498854
 GameObject:
   m_ObjectHideFlags: 0
@@ -272,6 +230,52 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1947875331
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
+      propertyPath: m_Name
+      value: FPSController
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1 &2019143982
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
・プレイ動画　※分かり易くする為に動画にだけCubeが配置してあります。
![f4fc2f23d9a30568e58a0a009ab3287c](https://user-images.githubusercontent.com/40168162/41831334-6149d668-7881-11e8-9623-c0b531db5d42.gif)

FirstPersonControllerにしゃがみ機能を追加
「c」を押すとしゃがむ
しゃがんだ状態での移動は遅くなる

・変更内容
bool m_IsCrouching、
float m_CrouchSpeed（[SerializeField] privateで2.5に設定）、
float m_CrouchHeadDistance（[SerializeField] privateで0.6に設定、その数値だけ頭の位置が下がる）
を追加。
Commandスクリプトを追加。

コマンドパターンデザインを適応、
m_IsCrouchingをｃキーが押されている時に正になるようにし、
m_IsCrouching が正の時にspeed を m_CrouchSpeedにする。

UpdateCameraPosition関数内でm_IsCrouching が正の時にnewCameraPosition.y を m_OriginalCameraPosition.y - m_CrouchHeadDistanceにする。

