### PR TITLE
リロード機能の追加

### DIFF
--- a/FPS-Space/Assets/ImportedAssets/Standard Assets/Characters/FirstPersonCharacter/Scripts/GunManager.cs
+++ b/FPS-Space/Assets/ImportedAssets/Standard Assets/Characters/FirstPersonCharacter/Scripts/GunManager.cs
@@ -55,12 +55,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
 		private void GetInput()
 		{
-			if (Input.GetMouseButton(0))
+			if (Input.GetMouseButton(0) && CanFire())
 			{
 				Fire();
 			}
 			
-			if (Input.GetKeyDown(KeyCode.R))
+			if (Input.GetKeyDown(KeyCode.R) && CanReload())
 			{
 				Reload();
 			}
@@ -69,8 +69,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
 		private void Fire()
 		{
-			if(!CanFire()) return;
-			
 			m_bulletsInMagazine -= 1;
 			m_isCoolTime = true;
 			FireSound();
@@ -87,13 +85,11 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		{
 			m_muzzleFlash = Instantiate(m_sparkle, m_muzzle.transform.position, m_muzzle.transform.rotation, m_muzzle.transform) as GameObject;
 			StartCoroutine (((Func<IEnumerator>)DestroyMuzzleFlash).Method.Name);
-			
-			if (IsHit())
-			{
-				HitSparkleOffset();
-				m_hitSparkle = Instantiate(m_sparkle, m_hitPosition, m_muzzle.transform.rotation) as GameObject;
-				StartCoroutine (((Func<IEnumerator>)DestroyHitSparkle).Method.Name);
-			}
+
+			if (!IsHit()) return;
+			HitSparkleOffset();
+			m_hitSparkle = Instantiate(m_sparkle, m_hitPosition, m_muzzle.transform.rotation) as GameObject;
+			StartCoroutine (((Func<IEnumerator>)DestroyHitSparkle).Method.Name);
 		}
 
 		private IEnumerator SetCoolTime()
@@ -156,13 +152,16 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
 		private bool CanFire()
 		{
-			return !m_isCoolTime && m_bulletsInMagazine >= 1;
+			return !m_isCoolTime && HasBulletsInMagazine();
+		}
+
+		private bool HasBulletsInMagazine()
+		{
+			return m_bulletsInMagazine >= 1;
 		}
 
 		private void Reload()
 		{
-			if (!CanReload()) return;
-
 			ReloadSound();
 
 			int i = (m_magazineSize - m_bulletsInMagazine);
@@ -187,8 +186,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
 		private bool CanReload()
 		{
-			return m_hasAmmo && m_bulletsInMagazine != m_magazineSize;
+			return m_hasAmmo && IsMagazineFull();
 		}
 
+		private bool IsMagazineFull()
+		{
+			return m_bulletsInMagazine != m_magazineSize;
+		}
 	}
 }

--- a/FPS-Space/Assets/Main.unity
+++ b/FPS-Space/Assets/Main.unity
@@ -182,9 +182,39 @@ Prefab:
       propertyPath: BypassReverbZones
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 114723617946033080, guid: 454a6cbacf7b20546abb6c35035e6a17,
+        type: 2}
+      propertyPath: m_camera
+      value: 
+      objectReference: {fileID: 985471450}
+    - target: {fileID: 114499057869495034, guid: 454a6cbacf7b20546abb6c35035e6a17,
+        type: 2}
+      propertyPath: m_ammoLimit
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 114499057869495034, guid: 454a6cbacf7b20546abb6c35035e6a17,
+        type: 2}
+      propertyPath: m_fireSound
+      value: 
+      objectReference: {fileID: 8300000, guid: 8602b7d5cd15c1943a50aa53f171c8cf, type: 3}
+    - target: {fileID: 114499057869495034, guid: 454a6cbacf7b20546abb6c35035e6a17,
+        type: 2}
+      propertyPath: m_reloadSound
+      value: 
+      objectReference: {fileID: 8300000, guid: 3c5c1d4d7b9307c458890a4beb12e4ae, type: 3}
+    - target: {fileID: 114499057869495034, guid: 454a6cbacf7b20546abb6c35035e6a17,
+        type: 2}
+      propertyPath: m_magazineSize
+      value: 30
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 454a6cbacf7b20546abb6c35035e6a17, type: 2}
   m_IsPrefabParent: 0
+--- !u!20 &985471450 stripped
+Camera:
+  m_PrefabParentObject: {fileID: 20753029954671866, guid: 454a6cbacf7b20546abb6c35035e6a17,
+    type: 2}
+  m_PrefabInternal: {fileID: 985471449}
 --- !u!1 &1765498854
 GameObject:
   m_ObjectHideFlags: 0

--- a/FPS-Space/Assets/Prefabs/FPSController.prefab
+++ b/FPS-Space/Assets/Prefabs/FPSController.prefab
@@ -521,7 +521,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_muzzle: {fileID: 1343369186204602}
   m_sparkle: {fileID: 1648515579763438, guid: 49649e0db33c1de4ea760532dd259b1b, type: 2}
-  m_audioClip: {fileID: 8300000, guid: 8602b7d5cd15c1943a50aa53f171c8cf, type: 3}
+  m_coolTime: 0
+  m_sparkleLifeTime: 0
+  m_offset: 0
+  m_ammoLimit: 0
+  m_fireSound: {fileID: 0}
   m_firstPersonCamera: {fileID: 114723617946033080}
 --- !u!114 &114515726552715510
 MonoBehaviour:
@@ -560,6 +564,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf0c7c7d1030ff744b790a6b31fdd80f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_camera: {fileID: 20753029954671866}
   m_mouseLook:
     XSensitivity: 2
     YSensitivity: 2


### PR DESCRIPTION
弾薬数の設定
弾薬上限数の設定
弾倉の設定
リロード機能
リロード音の設定

※変更内容
・[SerializeField] private int で m_ammoLimit　を150, m_magazineSize を30に設定。
m_currentAmmoで所持弾薬数を管理、m_bulletsInMagazineで弾倉内弾薬数を管理。
・Rキーが押された時かつ所持弾薬数が1以上かつ弾倉内弾薬数が30でない時にリロード。
・（30 - 弾倉内弾薬数）か所持弾薬数のどちらか少ないほうを弾倉内弾薬数に足す。
・弾倉内弾薬数が1未満の時は発砲は不可
・リロード時 Reload Soundを再生。